### PR TITLE
Remove emacs22 from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@
 
 env:
   matrix:
-#   - EMACS=xemacs21
-    - EMACS=emacs22
     - EMACS=emacs23
     - EMACS=emacs24
     - EMACS=emacs-snapshot
@@ -47,8 +45,6 @@ env:
 
 matrix:
   allow_failures:
-#   - env: EMACS=xemacs21
-    - env: EMACS=emacs22
     - env: EMACS=emacs-snapshot
 
 ###


### PR DESCRIPTION
It doesn't already work, and I don't want to support it along with 23
and 24
